### PR TITLE
Multi partition support

### DIFF
--- a/src/onyx/kafka/utils.clj
+++ b/src/onyx/kafka/utils.clj
@@ -1,5 +1,6 @@
 (ns onyx.kafka.utils
   (:require [clj-kafka.consumer.zk :as zkconsumer]
+            [taoensso.timbre :refer [info] :as timbre]
             [clj-kafka.core :as zkcore]))
 
 (defn take-segments

--- a/src/onyx/plugin/kafka.clj
+++ b/src/onyx/plugin/kafka.clj
@@ -128,7 +128,8 @@
 
 (defn check-num-peers-equals-partitions [{:keys [onyx/min-peers onyx/max-peers] :as task-map} 
                                          n-partitions]
-  (when-not (= n-partitions min-peers max-peers)
+  (when-not (or (= n-partitions min-peers max-peers)
+                (= 1 n-partitions max-peers))
     (let [e (ex-info ":onyx/min-peers must equal :onyx/max-peers and the number of kafka partitions" 
                      {:n-partitions n-partitions 
                       :min-peers min-peers

--- a/src/onyx/plugin/kafka_log.clj
+++ b/src/onyx/plugin/kafka_log.clj
@@ -1,0 +1,32 @@
+(ns onyx.plugin.kafka-log
+  (:require [onyx.extensions :as extensions]))
+
+(defn allocate-partition [replica {:keys [job-id task-id peer-id n-partitions] :as args}]
+  (let [task-allocations (get-in (:allocations replica) [job-id task-id])] 
+    (if (some #{peer-id} task-allocations)
+      (let [kafka-allocations (-> replica 
+                                  (get-in [:task-metadata job-id task-id])
+                                  (select-keys task-allocations))
+            remaining-partitions (remove (set (vals kafka-allocations)) (range n-partitions))
+            new-kafka-allocations (assoc kafka-allocations peer-id (first remaining-partitions))] 
+        (assoc-in replica [:task-metadata job-id task-id] new-kafka-allocations))
+      replica)))
+
+(defmethod extensions/apply-log-entry :allocate-kafka-partition
+  [{:keys [args]} replica]
+  (allocate-partition replica args))
+
+(defmethod extensions/replica-diff :allocate-kafka-partition
+  [entry old new]
+  {})
+
+(defmethod extensions/reactions :allocate-kafka-partition
+  [{:keys [args]} old new diff state]
+  [])
+
+(defmethod extensions/fire-side-effects! :allocate-kafka-partition
+  [{:keys [args]} old new diff state]
+  ;; it may be possible to place the reader-loop future in here
+  ;; currently there are too many parameters missing, and it will be awkward
+  ;; to stop the future on shutdown
+  state)

--- a/test/onyx/plugin/input_log.clj
+++ b/test/onyx/plugin/input_log.clj
@@ -3,34 +3,37 @@
             [midje.sweet :refer :all]))
 
 (fact "Allocate from scratch"
-      (kl/allocate-partition {:allocations {:task-a [:peer-3]}}
+      (kl/allocate-partition {:allocations {:job-1 {:task-a [:peer-3]}}}
                              {:n-partitions 5
+                              :job-id :job-1
                               :task-id :task-a 
                               :peer-id :peer-3})
       => 
-      {:task-metadata {:task-a {:peer-3 0}}
-       :allocations {:task-a [:peer-3]}})
+      {:task-metadata {:job-1 {:task-a {:peer-3 0}}}
+       :allocations {:job-1 {:task-a [:peer-3]}}})
 
 (fact "Allocate, however peer is no longer allocated to task"
-      (kl/allocate-partition {:allocations {:task-a []}}
+      (kl/allocate-partition {:allocations {:job-1 {:task-a []}}}
                              {:n-partitions 5
+                              :job-id :job-1
                               :task-id :task-a 
                               :peer-id :peer-3})
       => 
-      {:allocations {:task-a []}})
+      {:allocations {:job-1 {:task-a []}}})
 
 (fact "Allocate a new peer, deallocate dropped peer"
-      (kl/allocate-partition {:task-metadata {:task-a {:peer-0 1
-                                                       :peer-1 0 
-                                                       :peer-2 3}}
-                              :allocations {:task-a [:peer-1 
-                                                     :peer-2
-                                                     :peer-3]}}
+      (kl/allocate-partition {:task-metadata {:job-1 {:task-a {:peer-0 1
+                                                               :peer-1 0 
+                                                               :peer-2 3}}}
+                              :allocations {:job-1 {:task-a [:peer-1 
+                                                             :peer-2
+                                                             :peer-3]}}}
                              {:n-partitions 5
+                              :job-id :job-1
                               :task-id :task-a 
                               :peer-id :peer-3})
       => 
-      {:task-metadata {:task-a {:peer-1 0 
-                                :peer-2 3 
-                                :peer-3 1}}
-       :allocations {:task-a [:peer-1 :peer-2 :peer-3]}})
+      {:task-metadata {:job-1 {:task-a {:peer-1 0 
+                                        :peer-2 3 
+                                        :peer-3 1}}}
+       :allocations {:job-1 {:task-a [:peer-1 :peer-2 :peer-3]}}})

--- a/test/onyx/plugin/input_log.clj
+++ b/test/onyx/plugin/input_log.clj
@@ -1,0 +1,36 @@
+(ns onyx.plugin.input-log
+  (:require [onyx.plugin.kafka-log :as kl]
+            [midje.sweet :refer :all]))
+
+(fact "Allocate from scratch"
+      (kl/allocate-partition {:allocations {:task-a [:peer-3]}}
+                             {:n-partitions 5
+                              :task-id :task-a 
+                              :peer-id :peer-3})
+      => 
+      {:task-metadata {:task-a {:peer-3 0}}
+       :allocations {:task-a [:peer-3]}})
+
+(fact "Allocate, however peer is no longer allocated to task"
+      (kl/allocate-partition {:allocations {:task-a []}}
+                             {:n-partitions 5
+                              :task-id :task-a 
+                              :peer-id :peer-3})
+      => 
+      {:allocations {:task-a []}})
+
+(fact "Allocate a new peer, deallocate dropped peer"
+      (kl/allocate-partition {:task-metadata {:task-a {:peer-0 1
+                                                       :peer-1 0 
+                                                       :peer-2 3}}
+                              :allocations {:task-a [:peer-1 
+                                                     :peer-2
+                                                     :peer-3]}}
+                             {:n-partitions 5
+                              :task-id :task-a 
+                              :peer-id :peer-3})
+      => 
+      {:task-metadata {:task-a {:peer-1 0 
+                                :peer-2 3 
+                                :peer-3 1}}
+       :allocations {:task-a [:peer-1 :peer-2 :peer-3]}})

--- a/test/onyx/plugin/input_resume_test.clj
+++ b/test/onyx/plugin/input_resume_test.clj
@@ -69,7 +69,6 @@
     :onyx/type :input
     :onyx/medium :kafka
     :kafka/topic topic
-    :kafka/partition "0"
     :kafka/group-id "onyx-consumer"
     :kafka/fetch-size 307200
     :kafka/chan-capacity 1000

--- a/test/onyx/plugin/input_test.clj
+++ b/test/onyx/plugin/input_test.clj
@@ -133,6 +133,7 @@
   :lifecycles lifecycles
   :task-scheduler :onyx.task-scheduler/balanced})
 
+;; remove me after learning how to handle the sentinel
 (Thread/sleep 10000)
 
 (kp/send-message producer (kp/message topic (.getBytes (pr-str :done))))


### PR DESCRIPTION
This is an initial implementation of multi-partition reader support.

There are a couple issues:
- treatment of `:done` is incorrect for multiple partitions, as it will only be written to one partition, and you can no longer rely on all the messages being read.
- the custom log messages add to `:task-metadata`, and there is currently no way to clean up this data when the job finishes, or tasks die.

For the `:done` handling, I'm fine with disabling batch support for multiple partitions for now. However, the only way to handle this would be to throw an exception when a done is encountered and multiple partitions were supplied. This is obviously not ideal as it fails pretty late.

For the custom log messages, I think if we keep the structure pretty standard, i.e. :task-metadata / job-id / task-id / peer-id, then we can just dissoc from a couple places when peers get reallocated, or when jobs get killed and finish.
