### PR TITLE
Add :kafka/wrap-message? parameter and handle it

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Lifecycle entry:
 |`:kafka/empty-read-back-off`| `integer` |`500`    | The amount of time to back off between reads when nothing was fetched from a consumer
 |`:kafka/commit-interval`    | `integer` |`2000`   | The interval in milliseconds to commit the latest acknowledged offset to ZooKeeper
 |`:kafka/deserializer-fn`    | `keyword` |         | A keyword that represents a fully qualified namespaced function to deserialize a message. Takes one argument - a byte array
+|`:kafka/wrap-message?`      | `boolean` |`false`  | Wraps message into map with keys `:offset`, `:partition`, `:topic` and `:message` itself
 
 ##### write-messages
 

--- a/src/onyx/plugin/kafka.clj
+++ b/src/onyx/plugin/kafka.clj
@@ -20,7 +20,8 @@
    :kafka/request-size 307200
    :kafka/chan-capacity 1000
    :kafka/empty-read-back-off 500
-   :kafka/commit-interval 2000})
+   :kafka/commit-interval 2000
+   :kafka/wrap-message? false})
 
 (defn log-id [replica-val job-id peer-id task-id]
   (get-in replica-val [:task-slot-ids job-id task-id peer-id]))
@@ -93,7 +94,11 @@
               empty-read-back-off (or (:kafka/empty-read-back-off task-map) (:kafka/empty-read-back-off defaults))
               commit-interval (or (:kafka/commit-interval task-map) (:kafka/commit-interval defaults))
               commit-fut (future (commit-loop group-id m topic kpartition commit-interval pending-commits))
-              deserializer-fn (kw->fn (:kafka/deserializer-fn task-map))]
+              deserializer-fn (kw->fn (:kafka/deserializer-fn task-map))
+              wrap-message? (or (:kafka/wrap-message? task-map) (:kafka/wrap-message? defaults))
+              wrapper-fn (if wrap-message?
+                           (fn [msg off] {:offset off :message msg :topic topic :partitions kpartition})
+                           (fn [msg off] msg))]
           (log/info (str "Kafka consumer is starting at offset " offset))
           (try
             (loop [ms (kc/messages consumer "onyx" topic kpartition offset fetch-size)
@@ -104,8 +109,9 @@
                   (recur fetched head-offset))
                 (let [message ^KafkaMessage (first ms)
                       next-offset ^int (.offset message)
-                      dm (deserializer-fn (.value message))]
-                  (>!! ch (assoc (t/input (random-uuid) dm)
+                      dm (deserializer-fn (.value message))
+                      wrapped (wrapper-fn dm next-offset)]
+                  (>!! ch (assoc (t/input (random-uuid) wrapped)
                                  :offset next-offset))
                   (recur (rest ms) (inc next-offset)))))
             (finally


### PR DESCRIPTION
I added documentation for a flag and implemented it, but didn't write test yet. What's the best way to add a test for the parameter? Should I just duplicate `onyx.plugin.input-test` with proper name and change relevant parts? Or somehow extend existing test?
