### PR TITLE
Fix documentation for :kafka/wrap-with-metadata?

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Lifecycle entry:
 |`:kafka/empty-read-back-off`| `integer` |`500`    | The amount of time to back off between reads when nothing was fetched from a consumer
 |`:kafka/commit-interval`    | `integer` |`2000`   | The interval in milliseconds to commit the latest acknowledged offset to ZooKeeper
 |`:kafka/deserializer-fn`    | `keyword` |         | A keyword that represents a fully qualified namespaced function to deserialize a message. Takes one argument - a byte array
-|`:kafka/wrap-with-metadata?`| `boolean` |`false`  | Wraps message into map with keys `:offset`, `:partitions`, `:topic` and `:message` itself
+|`:kafka/wrap-with-metadata?`| `boolean` |`false`  | Wraps message into map with keys `:offset`, `:partition`, `:topic`, `:key` and `:message` itself
 
 ##### write-messages
 


### PR DESCRIPTION
Readme stated that `:kafka/wrap-with-metadata?` has this effect: 

> Wraps message into map with keys `:offset`, `:partitions`, `:topic` and `:message` itself. 

However, it also adds `:key` now, and it adds `:partition` instead of `:partitions`. I made an error when named it `:partitions`, and seems like you corrected it only in source code: https://github.com/onyx-platform/onyx-kafka/blob/0.8.8.0/src/onyx/plugin/kafka.clj#L106
