### PR TITLE
Add support for pulling topic name from message

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,16 @@ Lifecycle entry:
  :lifecycle/calls :onyx.plugin.kafka/write-messages-calls}
 ```
 
-Segments supplied to a write-messages task should be in in the following form:
-`{:message message-body}` with optional partition and key values e.g.
-`{:message message-body :key optional-key :partition optional-partition}`.
+Segments supplied to a `:onyx.plugin.kafka/write-messages` task should be in in
+the following form: `{:message message-body}` with optional partition, topic and
+key values.
+
+``` clj
+{:message message-body
+ :key optional-key
+ :partition optional-partition
+ :topic optional-topic}
+```
 
 ###### Attributes
 

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                              :sign-releases false}}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  ^{:voom {:repo "git@github.com:onyx-platform/onyx.git" :branch "master"}}
-                 [org.onyxplatform/onyx "0.9.7-beta2"]
+                 [org.onyxplatform/onyx "0.9.7-20160704.165927-33"]
                  [ymilky/franzy "0.0.1"]
                  [ymilky/franzy-admin "0.0.1" :exclusions [org.slf4j/slf4j-log4j12]]
                  [ymilky/franzy-embedded "0.0.1" :exclusions [org.slf4j/slf4j-log4j12]]

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,11 +1,5 @@
 {:env-config
  {:onyx/tenancy-id #env [ONYX_ID "testcluster"]
-  :onyx.bookkeeper/server? true
-  :onyx.bookkeeper/local-quorum? #cond {:default false
-                                        :test true}
-  :onyx.bookkeeper/delete-server-data? true
-  :onyx.bookkeeper/local-quorum-ports [3196 3197 3198]
-  :onyx.bookkeeper/port 3196
   :zookeeper/address #cond {:default #env [ZOOKEEPER "zookeeper"]
                             :test "127.0.0.1:2188"}
   :zookeeper/server? #cond {:default false

--- a/src/onyx/kafka/utils.clj
+++ b/src/onyx/kafka/utils.clj
@@ -42,7 +42,7 @@
        (loop [results []]
          (let [msgs (into [] (poll! c))
                segments
-               (map (partial consumer-record->message decompress-fn) msgs)]
+               (map #(consumer-record->message decompress-fn %) msgs)]
            (if (= :done (:value (last segments)))
              (into results (butlast segments))
              (recur (into results segments)))))))))
@@ -54,7 +54,7 @@
   (log/info {:msg "Taking now..." :topic topic})
   (let [c (make-consumer zk-addr)]
     (assign-partitions! c [{:topic topic :partition 0}])
-    (mapv (partial consumer-record->message decompress-fn) (poll! c))))
+    (mapv #(consumer-record->message decompress-fn %) (poll! c))))
 
 (defn take-segments
   "Reads segments from a topic until a :done is reached."

--- a/src/onyx/kafka/utils.clj
+++ b/src/onyx/kafka/utils.clj
@@ -3,32 +3,58 @@
             [franzy.clients.consumer.protocols :refer [poll! assign-partitions!]]
             [franzy.serialization.serializers :refer [byte-array-serializer]]
             [franzy.serialization.deserializers :refer [byte-array-deserializer]]
-            [onyx.plugin.kafka :refer [id->broker]]))
+            [onyx.plugin.kafka :refer [id->broker]]
+            [taoensso.timbre :as log]
+            [clojure.core.async :as async]))
+
+(defmacro ^:private timeout
+  {:indent 1}
+  [ms & body]
+  `(let [ch# (async/thread ~@body)]
+     (first (async/alts!! [ch# (async/timeout ~ms)]))))
+
+(defn- make-consumer
+  [zk-addr]
+  (consumer/make-consumer
+   {:bootstrap.servers (vals (id->broker zk-addr))
+    :group.id "onyx-consumer"
+    :auto.offset.reset :earliest
+    :enable.auto.commit false}
+   (byte-array-deserializer)
+   (byte-array-deserializer)))
+
+(defn- consumer-record->message
+  [decompress-fn m]
+  (log/info {:task ::consumer-record->message :msg m})
+  {:key (some-> m :key decompress-fn)
+   :partition (:partition m)
+   :topic (:topic m)
+   :value (-> m :value decompress-fn)})
 
 (defn take-until-done
   "Reads from a topic until a :done is reached."
   ([zk-addr topic decompress-fn] (take-until-done zk-addr topic decompress-fn {}))
   ([zk-addr topic decompress-fn opts]
-   (let [config {:bootstrap.servers (vals (id->broker zk-addr))
-                 :group.id "onyx-consumer"
-                 :auto.offset.reset :earliest
-                 :enable.auto.commit false}
-         key-deserializer (byte-array-deserializer)
-         value-deserializer (byte-array-deserializer)
-         c (consumer/make-consumer config key-deserializer value-deserializer)]
-     (assign-partitions! c [{:topic topic :partition 0}])
-     (loop [results []]
-       (let [msgs (into [] (poll! c))
-             segments
-             (map
-              (fn [m]
-                {:key (when (:key m) (decompress-fn (:key m)))
-                 :value (decompress-fn (:value m))
-                 :partition (:partition m)})
-              msgs)]
-         (if (= :done (:value (last segments)))
-           (into results (butlast segments))
-           (recur (into results segments))))))))
+   (log/info {:msg "Taking until done..." :topic topic})
+   (timeout 5000
+     (let [c (make-consumer zk-addr)]
+       (assign-partitions! c [{:topic topic :partition 0}])
+       (loop [results []]
+         (let [msgs (into [] (poll! c))
+               segments
+               (map (partial consumer-record->message decompress-fn) msgs)]
+           (if (= :done (:value (last segments)))
+             (into results (butlast segments))
+             (recur (into results segments)))))))))
+
+(defn take-now
+  "Reads whatever it can from a topic on the assumption that we've distributed
+  work across multiple topics and another topic contained :done."
+  [zk-addr topic decompress-fn]
+  (log/info {:msg "Taking now..." :topic topic})
+  (let [c (make-consumer zk-addr)]
+    (assign-partitions! c [{:topic topic :partition 0}])
+    (mapv (partial consumer-record->message decompress-fn) (poll! c))))
 
 (defn take-segments
   "Reads segments from a topic until a :done is reached."

--- a/src/onyx/plugin/kafka.clj
+++ b/src/onyx/plugin/kafka.clj
@@ -343,8 +343,8 @@
       (doall
        (->> messages
             (map :message)
-            (map (partial message->producer-record this))
-            (map (partial send-async! producer))
+            (map #(message->producer-record this %))
+            (map #(send-async! producer %))
             (map deref)))
       {}))
 

--- a/src/onyx/plugin/kafka.clj
+++ b/src/onyx/plugin/kafka.clj
@@ -312,6 +312,25 @@
   [event lifecycle]
   (.close (:kafka/producer event)))
 
+(defn- message->producer-record
+  [{:keys [serializer-fn topic]} m]
+  (let [message (:message m)
+        k (some-> m :key serializer-fn)
+        p (some-> m :partition int)
+        message-topic (get m :topic topic)]
+    (cond
+      (nil? message)
+      (throw (ex-info "Payload is missing required :message!"
+                      {:payload m}))
+      (nil? message-topic)
+      (throw (ex-info
+              (str "Unable to write message payload to Kafka! "
+                   "Both :kafka/topic, and :topic in message payload "
+                   "are missing!")
+              {:payload m}))
+      :else
+      (ProducerRecord. message-topic p k (serializer-fn message)))))
+
 (defrecord KafkaWriteMessages [task-map config topic producer serializer-fn]
   p-ext/Pipeline
   (read-batch
@@ -319,20 +338,14 @@
     (function/read-batch event))
 
   (write-batch
-    [_ {:keys [onyx.core/results]}]
-    (let [messages (mapcat :leaves (:tree results))
-          send-futs (map (fn [m]
-                           (let [k-message (:message m)
-                                 k-key (some-> m :key serializer-fn)
-                                 p (some-> m :partition int)
-                                 message-topic (get m :topic topic)]
-                             (assert
-                              k-message
-                              (str "Payload missing required :message! Got "
-                                   (pr-str m)))
-                             (send-async! producer (ProducerRecord. message-topic p k-key (serializer-fn k-message)))))
-                         (map :message messages))]
-      (doall (map deref send-futs))
+    [this {:keys [onyx.core/results]}]
+    (let [messages (mapcat :leaves (:tree results))]
+      (doall
+       (->> messages
+            (map :message)
+            (map (partial message->producer-record this))
+            (map (partial send-async! producer))
+            (map deref)))
       {}))
 
   (seal-resource

--- a/src/onyx/plugin/kafka.clj
+++ b/src/onyx/plugin/kafka.clj
@@ -324,10 +324,13 @@
           send-futs (map (fn [m]
                            (let [k-message (:message m)
                                  k-key (some-> m :key serializer-fn)
-                                 p (some-> m :partition int)]
-                             (assert k-message
-                                     "Messages must be supplied in a map in form {:message :somevalue}, with optional :key and :partition keys.")
-                             (send-async! producer (ProducerRecord. topic p k-key (serializer-fn k-message)))))
+                                 p (some-> m :partition int)
+                                 message-topic (get m :topic topic)]
+                             (assert
+                              k-message
+                              (str "Payload missing required :message! Got "
+                                   (pr-str m)))
+                             (send-async! producer (ProducerRecord. message-topic p k-key (serializer-fn k-message)))))
                          (map :message messages))]
       (doall (map deref send-futs))
       {}))

--- a/src/onyx/tasks/kafka.clj
+++ b/src/onyx/tasks/kafka.clj
@@ -72,7 +72,7 @@
   (.getBytes (pr-str segment)))
 
 (def KafkaOutputTaskMap
-  {:kafka/topic s/Str
+  {(s/optional-key :kafka/topic) s/Str
    :kafka/zookeeper s/Str
    :kafka/serializer-fn os/NamespacedKeyword
    :kafka/request-size s/Num

--- a/test/onyx/plugin/output_test.clj
+++ b/test/onyx/plugin/output_test.clj
@@ -57,6 +57,7 @@
       (with-test-env [test-env [4 env-config peer-config]]
         (onyx.test-helper/validate-enough-peers! test-env job)
         (reset! mock (test-utils/mock-kafka test-topic zk-address []))
+        (test-utils/create-topic zk-address other-test-topic)
         (pipe (spool test-data) in) ;; Pipe data from test-data to the in channel
         (->> (onyx.api/submit-job peer-config job)
              :job-id

--- a/test/onyx/plugin/output_test.clj
+++ b/test/onyx/plugin/output_test.clj
@@ -1,7 +1,7 @@
 (ns onyx.plugin.output-test
   (:require [clojure.core.async :refer [<!! go pipe]]
             [clojure.core.async.lab :refer [spool]]
-            [clojure.test :refer [deftest is]]
+            [clojure.test :refer [deftest is testing]]
             [com.stuartsierra.component :as component]
             [franzy.admin.zookeeper.client :as k-admin]
             [franzy.admin.cluster :as k-cluster]
@@ -9,16 +9,18 @@
             [onyx.test-helper :refer [with-test-env]]
             [onyx.job :refer [add-task]]
             [onyx.kafka.embedded-server :as ke]
-            [onyx.kafka.utils :refer [take-until-done]]
+            [onyx.kafka.utils :refer [take-now take-until-done]]
             [onyx.tasks.kafka :refer [producer]]
             [onyx.tasks.core-async :as core-async]
             [onyx.plugin.core-async :refer [get-core-async-channels]]
             [onyx.plugin.test-utils :as test-utils]
             [onyx.plugin.kafka]
-            [onyx.api]))
+            [onyx.api]
+            [taoensso.timbre :as log]))
 
 (defn build-job [zk-address topic batch-size batch-timeout]
-  (let [batch-settings {:onyx/batch-size batch-size :onyx/batch-timeout batch-timeout}
+  (let [batch-settings {:onyx/batch-size batch-size
+                        :onyx/batch-timeout batch-timeout}
         base-job (merge {:workflow   [[:in :identity]
                                       [:identity :write-messages]]
                          :catalog [(merge {:onyx/name :identity
@@ -38,6 +40,18 @@
                                         :kafka/serializer-fn :onyx.tasks.kafka/serialize-message-edn
                                         :kafka/request-size 307200}
                                        batch-settings))))))
+
+(defn- decompress
+  [v]
+  (when v
+    (read-string (String. v "UTF-8"))))
+
+(defn- prepare-messages
+  [coll]
+  (log/infof "Preparing %d messages..." (count coll))
+  (->> coll
+       (sort-by (comp :n :value))
+       (map #(select-keys % [:key :partition :topic :value]))))
 
 (deftest kafka-output-test
   (let [test-topic (str "onyx-test-" (java.util.UUID/randomUUID))
@@ -62,15 +76,20 @@
         (->> (onyx.api/submit-job peer-config job)
              :job-id
              (onyx.test-helper/feedback-exception! peer-config))
-        (is (= (->> (take-until-done zk-address test-topic (fn [v] (read-string (String. v "UTF-8"))))
-                    (sort-by (comp :n :value))
-                    (mapv (fn [msg]
-                            (select-keys msg [:key :value :partition]))))
-               [{:key 1 :value {:n 0} :partition 0}
-                {:key nil :value {:n 1} :partition 0}
-                {:key "tarein" :value {:n 2} :partition 0}]))
-        (is (= [{:key nil :value {:n 3} :partition 0 :topic other-test-topic}]
-               (take-until-done
-                zk-address other-test-topic
-                (fn [v] (read-string (String. v "UTF-8")))))))
-      (finally (swap! mock component/stop)))))
+        (testing "routing to default topic"
+          (log/info "Waiting on messages in" test-topic)
+          (let [msgs (prepare-messages
+                      (take-until-done zk-address test-topic decompress))]
+            (is (= [test-topic] (->> msgs (map :topic) distinct)))
+            (is (= [{:key 1 :value {:n 0} :partition 0}
+                    {:key nil :value {:n 1} :partition 0}
+                    {:key "tarein" :value {:n 2} :partition 0}]
+                   (map #(dissoc % :topic) msgs)))))
+        (testing "overriding the topic"
+          (log/info "Waiting on messages in" other-test-topic)
+          (is (= [{:key nil :value {:n 3} :partition 0 :topic other-test-topic}]
+                 (prepare-messages
+                  (take-now zk-address other-test-topic decompress))))))
+      (finally
+        (log/info "Stopping mock Kafka...")
+        (swap! mock component/stop)))))

--- a/test/onyx/plugin/output_test.clj
+++ b/test/onyx/plugin/output_test.clj
@@ -68,7 +68,7 @@
                [{:key 1 :value {:n 0} :partition 0}
                 {:key nil :value {:n 1} :partition 0}
                 {:key "tarein" :value {:n 2} :partition 0}]))
-        (is (= [{:key nil :value {:n 3} :partition 0 :topic "message-specific"}]
+        (is (= [{:key nil :value {:n 3} :partition 0 :topic other-test-topic}]
                (take-until-done
                 zk-address other-test-topic
                 (fn [v] (read-string (String. v "UTF-8")))))))

--- a/test/onyx/plugin/test_utils.clj
+++ b/test/onyx/plugin/test_utils.clj
@@ -8,7 +8,8 @@
              [protocols :refer [send-sync!]]]
             [franzy.serialization.serializers :refer [byte-array-serializer]]
             [onyx.kafka.embedded-server :as ke]
-            [schema.core :as s])
+            [schema.core :as s]
+            [taoensso.timbre :as log])
   (:import franzy.clients.producer.types.ProducerRecord))
 
 ;; Set the log level, otherwise Kafka emits a huge amount
@@ -18,6 +19,10 @@
 (s/defn create-topic
   ([zk-address topic-name] (create-topic zk-address topic-name 1))
   ([zk-address :- s/Str topic-name :- s/Str partitions :- s/Int]
+   (log/info {:msg "Creating new topic"
+              :zk-address zk-address
+              :topic-name topic-name
+              :partitions partitions})
    (k-topics/create-topic!
     (k-admin/make-zk-utils {:servers [zk-address]} false)
     topic-name

--- a/test/onyx/plugin/test_utils.clj
+++ b/test/onyx/plugin/test_utils.clj
@@ -1,19 +1,27 @@
 (ns onyx.plugin.test-utils
-  (:require [clojure.core.async :refer [go-loop <!! chan <! >!]]
+  (:require [clojure.core.async :refer [<! go-loop]]
             [com.stuartsierra.component :as component]
-            [franzy.admin.zookeeper.client :as k-admin]
-            [franzy.admin.cluster :as k-cluster]
             [franzy.admin.topics :as k-topics]
-            [franzy.clients.producer.client :as producer]
-            [franzy.clients.producer.protocols :refer [send-sync!]]
+            [franzy.admin.zookeeper.client :as k-admin]
+            [franzy.clients.producer
+             [client :as producer]
+             [protocols :refer [send-sync!]]]
             [franzy.serialization.serializers :refer [byte-array-serializer]]
-            [franzy.serialization.deserializers :refer [byte-array-deserializer]]
-            [onyx.kafka.embedded-server :as ke])
-  (:import [franzy.clients.producer.types ProducerRecord]))
+            [onyx.kafka.embedded-server :as ke]
+            [schema.core :as s])
+  (:import franzy.clients.producer.types.ProducerRecord))
 
 ;; Set the log level, otherwise Kafka emits a huge amount
 ;; of messages.
 (.setLevel (org.apache.log4j.LogManager/getRootLogger) org.apache.log4j.Level/WARN)
+
+(s/defn create-topic
+  ([zk-address topic-name] (create-topic zk-address topic-name 1))
+  ([zk-address :- s/Str topic-name :- s/Str partitions :- s/Int]
+   (k-topics/create-topic!
+    (k-admin/make-zk-utils {:servers [zk-address]} false)
+    topic-name
+    partitions)))
 
 (defn mock-kafka
   "Starts a Kafka in-memory instance, preloading a topic with xs.
@@ -28,8 +36,7 @@
                                            :log.dir log-dir
                                            :zookeeper.connect zookeeper
                                            :controlled.shutdown.enable false}))
-         zk-utils (k-admin/make-zk-utils {:servers [zookeeper]} false)
-         _ (k-topics/create-topic! zk-utils topic 1)
+         _ (create-topic zookeeper topic)
          config {:bootstrap.servers ["127.0.0.1:9092"]}
          key-serializer (byte-array-serializer)
          value-serializer (byte-array-serializer)

--- a/test/onyx/plugin/test_utils.clj
+++ b/test/onyx/plugin/test_utils.clj
@@ -21,7 +21,11 @@
    (k-topics/create-topic!
     (k-admin/make-zk-utils {:servers [zk-address]} false)
     topic-name
-    partitions)))
+    partitions
+    ;; Replication factor needs to be set because we're only running a single
+    ;; embedded Kafka server.
+    1
+    )))
 
 (defn mock-kafka
   "Starts a Kafka in-memory instance, preloading a topic with xs.


### PR DESCRIPTION
This makes it possible to override which topic is used when writing
messages to Kafka.

Simply include the topic name alongside your message, like so:

``` clj
{:message "Hello Kafka!"
 :topic "some.other.topic"}
```
