### PR TITLE
Use partition in message when it is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Onyx plugin providing read and write facilities for Kafka. This plugin automatically discovers broker locations from ZooKeeper and updates the consumers when there is a broker failover.
 
-This plugin version is *only compatible with Kafka 0.9+*. Please use [onyx-kafka-0.8](https://github.com/onyx-platform/onyx-kafka-0.8) with Kafka 0.8.
+This plugin version is *only compatible with Kafka 0.10+*. Please use [onyx-kafka-0.8](https://github.com/onyx-platform/onyx-kafka-0.8) with Kafka 0.8.
 
 #### Installation
 

--- a/src/onyx/plugin/kafka.clj
+++ b/src/onyx/plugin/kafka.clj
@@ -241,7 +241,7 @@
                    :payload m}))
 
           :else
-          (ProducerRecord. message-topic (int 0) k (serializer-fn message)))))
+          (ProducerRecord. message-topic message-partition k (serializer-fn message)))))
 
 (defn clear-write-futures! [fs]
   (doall (remove (fn [^java.util.concurrent.Future f] 


### PR DESCRIPTION
The docs state that the partition where a message is sent to can be set by providing a `:partition` entry, or else the `:kafka/partition` from the task attributes (when auto assignment is not used) 

However, in the code partition 0 is always used, this PR makes it use the `:partition` from the message, 
or else the `kafka/partition` from the task config