### PR TITLE
Use timestamp in message when it is provided

### DIFF
--- a/src/onyx/kafka/helpers.clj
+++ b/src/onyx/kafka/helpers.clj
@@ -2,7 +2,7 @@
   (:require [clojure.string :as string]
             [taoensso.timbre :as log])
   (:import [kafka.utils ZkUtils]
-           [org.apache.kafka.clients.consumer KafkaConsumer]
+           [org.apache.kafka.clients.consumer KafkaConsumer ConsumerRecord]
            [org.apache.kafka.clients.producer KafkaProducer Callback ProducerRecord]
            [org.apache.kafka.common.serialization ByteArrayDeserializer ByteArraySerializer Serializer Deserializer]
            [org.apache.kafka.common TopicPartition]
@@ -124,11 +124,12 @@
     (.seekToEnd ^KafkaConsumer consumer encoded)))
 
 (defn consumer-record->message
-  [decompress-fn m]
+  [decompress-fn ^ConsumerRecord m]
   {:key (some-> m (.key) decompress-fn)
    :partition (.partition m)
    :topic (.topic m)
-   :value (-> m (.value) decompress-fn)})
+   :value (-> m (.value) decompress-fn)
+   :timestamp (.timestamp m)})
 
 (defn poll! [consumer timeout]
   (.poll ^KafkaConsumer consumer timeout))

--- a/src/onyx/plugin/kafka.clj
+++ b/src/onyx/plugin/kafka.clj
@@ -226,7 +226,8 @@
   (let [message (:message m)
         k (some-> m :key key-serializer-fn)
         message-topic (get m :topic topic)
-        message-partition (some-> m (get :partition kpartition) int)]
+        message-partition  (some-> m (get :partition kpartition) int)
+        message-timestamp (some-> m (get :timestamp) long)]
     (cond (not (contains? m :message))
           (throw (ex-info "Payload is missing required. Need message key :message"
                           {:recoverable? false
@@ -241,7 +242,7 @@
                    :payload m}))
 
           :else
-          (ProducerRecord. message-topic message-partition k (serializer-fn message)))))
+          (ProducerRecord. ^String message-topic ^Integer message-partition ^Long message-timestamp k (serializer-fn message)))))
 
 (defn clear-write-futures! [fs]
   (doall (remove (fn [^java.util.concurrent.Future f] 


### PR DESCRIPTION
This makes it possible to set the timestamp of a kafka record by passing a `:timestamp` entry in the message

