### PR TITLE
Implement :kafka/target-offsets inclusively.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Lifecycle entry:
 |`:kafka/deserializer-fn`     | `keyword` |         | A keyword that represents a fully qualified namespaced function to deserialize a record's value. Takes one argument - a byte array
 |`:kafka/wrap-with-metadata?` | `boolean` |`false`  | Wraps message into map with keys `:key`, `:serialized-key-size`, `:serialized-value-size`, `:offset`, `:timestamp`, `:partition`, `:topic` and `:message` itself
 |`:kafka/start-offsets`       | `map`     |         | Allows a task to be supplied with the starting offsets for all partitions. Maps partition to offset, e.g. `{0 50, 1, 90}` will start at offset 50 for partition 0, and offset 90 for partition 1
-|`:kafka/target-offsets`      | `map`     |         | Allows a task to be supplied with target offsets for all partitions. Maps partition to target offset, e.g. `{0 50, 1 90}` and will cause the plugin to stop consuming records after reaching the specified offsets.
+|`:kafka/target-offsets`      | `map`     |         | Allows a task to be supplied with target offsets for all partitions. The consumer will read up to and including the target offset for each partition.
 |`:kafka/consumer-opts`       | `map`     |         | A map of arbitrary configuration to merge into the underlying Kafka consumer base configuration. Map should contain strings as keys, and the valid values described in the [Kafka Docs](http://kafka.apache.org/documentation.html#newconsumerconfigs).
 
 ##### write-messages

--- a/src/onyx/kafka/information_model.cljc
+++ b/src/onyx/kafka/information_model.cljc
@@ -100,7 +100,7 @@
               :optional? true}
 
              :kafka/target-offsets
-             {:doc "Allows a task to be supplied with target offsets for all partitions. Maps partition to target offset, e.g. `{0 50, 1 90}` and will cause the plugin to stop consuming records after reaching the specified offsets."
+             {:doc "Allows a task to be supplied with target offsets for all partitions. The consumer will read up to and including the target offset for each partition."
               :type :map
               :optional? true}}}
 

--- a/src/onyx/plugin/kafka.clj
+++ b/src/onyx/plugin/kafka.clj
@@ -201,7 +201,7 @@
                      kpartitions))
           resuming-tps (reduce-kv
                         (fn [all k v]
-                          (if (not= v :emitted)
+                          (if (not (some #{v} #{:emitted :drained}))
                             (conj all (TopicPartition. topic v))
                             all))
                         []

--- a/test/onyx/plugin/target_offsets_test.clj
+++ b/test/onyx/plugin/target_offsets_test.clj
@@ -79,9 +79,9 @@
                                                             [k (count v)]))
                                                      (group-by :partition first-results))]
                        (testing "We get the exact ammount of records requested, plus the final markers."
-                         (is (= (get partition-count-map 0) 21))
-                         (is (= (get partition-count-map 1) 26))
-                         (is (= (get partition-count-map 2) 31))
-                         (is (= (get partition-count-map 3) 36))))
+                         (is (= (get partition-count-map 0) 22))
+                         (is (= (get partition-count-map 1) 27))
+                         (is (= (get partition-count-map 2) 32))
+                         (is (= (get partition-count-map 3) 37))))
                      (println "Done taking segments")
                      (onyx.api/kill-job peer-config job-id)))))


### PR DESCRIPTION
Otherwise we cannot ever give the topic a point at which to stop, while
also reading the last message. We really want to read the final message and then close.